### PR TITLE
README/systemd: Set WantedBy to default.target

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ ExecStart=/home/pi/punchrclient --api-key <some-api-key>
 Restart=on-failure
 
 [Install]
-WantedBy=multiuser.target
+WantedBy=default.target
 ```
 
 To start the service run:

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ ExecStart=/home/pi/punchrclient --api-key <some-api-key>
 Restart=on-failure
 
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target
 ```
 
 To start the service run:


### PR DESCRIPTION
`multi-user.target` does not work on my raspberry pi, but `default.target` does. I.e. the former results in a systemd service on `inactive(dead)` and the latter results in a systemd unit `active` on startup. My vague understanding is that the former is for headless installations (which my pi is :confused:) and the latter is a catch-all.

Would appreciate if someone could test this on their machine where `multi-user.target` works.