### PR TITLE
rust-client: Prepare v0.2.1

### DIFF
--- a/rust-client/Cargo.lock
+++ b/rust-client/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "rust-client"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "clap",
  "either",

--- a/rust-client/Cargo.toml
+++ b/rust-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-client"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Rust implementation of the punchr project"
 repository = "https://github.com/dennis-tra/punchr"


### PR DESCRIPTION
Follow-up patch release to https://github.com/libp2p/punchr/pull/64.

//CC @thomaseizinger and @elenaf9 